### PR TITLE
AE-86 Plant unit tests for high level API in trie module

### DIFF
--- a/src/trie.erl
+++ b/src/trie.erl
@@ -1,10 +1,8 @@
 -module(trie).
 -behaviour(gen_server).
 -export([start_link/1,code_change/3,handle_call/3,handle_cast/2,handle_info/2,init/1,terminate/2, root_hash/2,cfg/1,get/3,put/5,delete/3,garbage/2,garbage_leaves/2,get_all/2]).
-init(CFG) -> 
-    StemID = ids:stem(CFG),
-    ReplaceStem = <<0:(8*(dump:word(StemID)))>>,
-    0 = dump:put(ReplaceStem, StemID),
+init(CFG) ->
+    0 = stem:put(stem:new_empty(CFG), CFG),
     {ok, CFG}.
 start_link(CFG) -> %keylength, or M is the size outputed by hash:doit(_). 
     gen_server:start_link({global, ids:main(CFG)}, ?MODULE, CFG, []).

--- a/test/trie_tests.erl
+++ b/test/trie_tests.erl
@@ -26,15 +26,25 @@ api_smoke_test_() ->
 	     ?assertNot(is_process_alive(SupPid)),
 	     ok
      end,
-     [ {"Put - happy path", fun put_happy_path/0}
+     [ {"Initialization produces empty trie", fun init_as_empty/0}
+     , {"Put - happy path", fun put_happy_path/0}
      , {"Get - case empty", fun get_empty/0}
      , {"Put long key", fun put_long_key/0}
      ]
     }.
 
+init_as_empty() ->
+    assert_trie_empty(_Root = 0, ?ID).
+
+assert_trie_empty(Root = 0, Id) ->
+    ?assertEqual([], trie:get_all(Root, Id)),
+    Cfg = trie:cfg(Id),
+    ?assertEqual(stem:new_empty(Cfg), stem:get(Root, Cfg)),
+    ok.
+
 put_happy_path() ->
-    ?assertEqual([], trie:get_all(0, ?ID)),
     Root = 0,
+    assert_trie_empty(Root, ?ID),
     Key = 1,
     V = <<1,1>>,
     Meta = 0,
@@ -46,13 +56,14 @@ put_happy_path() ->
     ok.
 
 get_empty() ->
-    ?assertEqual([], trie:get_all(0, ?ID)),
-    {_, empty, _} = trie:get(_Key = 1, _Root = 0, ?ID),
+    Root = 0,
+    assert_trie_empty(Root, ?ID),
+    ?assertMatch({_, empty, _}, trie:get(_Key = 1, Root, ?ID)),
     ok.
 
 put_long_key() ->
-    ?assertEqual([], trie:get_all(0, ?ID)),
     Root = 0,
+    assert_trie_empty(Root, ?ID),
     Key = 1 bsl cfg:path(trie:cfg(?ID)),
     V = <<1,1>>,
     Meta = 0,

--- a/test/trie_tests.erl
+++ b/test/trie_tests.erl
@@ -1,0 +1,73 @@
+-module(trie_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(ID, trieUnitTest).
+
+api_smoke_test_() ->
+    {foreach,
+     fun() ->
+	     ?debugFmt("~nCurrent working directory: ~p~n",
+		       [begin {ok, Cwd} = file:get_cwd(), Cwd end]),
+	     {ok, SupPid} =
+		 trie_sup:start_link(
+		   _KeyLength = 9,
+		   _Size = 2,
+		   _ID = ?ID,
+		   _Amount = 1000000,
+		   _Meta = 2,
+		   _HashSize = 12,
+		   _Mode = hd),
+	     ?debugFmt("~nTrie sup pid: ~p~n", [SupPid]),
+	     SupPid
+     end,
+     fun(SupPid) ->
+	     ?assert(is_process_alive(SupPid)),
+	     cleanup_alive_trie_sup(SupPid),
+	     ?assertNot(is_process_alive(SupPid)),
+	     ok
+     end,
+     [ {"Put - happy path", fun put_happy_path/0}
+     , {"Get - case empty", fun get_empty/0}
+     , {"Put long key", fun put_long_key/0}
+     ]
+    }.
+
+put_happy_path() ->
+    ?assertEqual([], trie:get_all(0, ?ID)),
+    Root = 0,
+    Key = 1,
+    V = <<1,1>>,
+    Meta = 0,
+    Root2 = trie:put(Key, V, Meta, Root, ?ID),
+    {Root2Hash, Leaf, Proof} = trie:get(Key, Root2, ?ID),
+    ?assertEqual(V, leaf:value(Leaf)),
+    ?assert(verify:proof(Root2Hash, Leaf, Proof, trie:cfg(?ID))),
+    ?assertEqual([Leaf], trie:get_all(Root2, ?ID)),
+    ok.
+
+get_empty() ->
+    ?assertEqual([], trie:get_all(0, ?ID)),
+    {_, empty, _} = trie:get(_Key = 1, _Root = 0, ?ID),
+    ok.
+
+put_long_key() ->
+    ?assertEqual([], trie:get_all(0, ?ID)),
+    Root = 0,
+    Key = 1 bsl cfg:path(trie:cfg(?ID)),
+    V = <<1,1>>,
+    Meta = 0,
+    Root2 = trie:put(Key, V, Meta, Root, ?ID),
+    {_, Leaf, _} = trie:get(Key, Root2, ?ID),
+    ?assertNotEqual(V, leaf:key(Leaf)),
+    ok.
+
+cleanup_alive_trie_sup(Sup) when is_pid(Sup) ->
+    SupMonRef = erlang:monitor(process, Sup),
+    unlink(Sup),
+    exit(Sup, Reason = shutdown),
+    receive
+	{'DOWN', SupMonRef, process, Sup, R} ->
+	    Reason = R,
+	    ok
+    end,
+    ok.


### PR DESCRIPTION
Please refer to commit message for details.

I feel I need to get a better understanding of the semantics of the key of the trie. At the moment in the code it is meant to be a [positive](https://github.com/BumblebeeBat/MerkleTrie/blob/a80b422c9fe0f3bbce1dbad6c32111c7e54883f0/src/leaf.erl#L23) integer, but the code behaves in a surprising way when the key is long. In test `put_long_key` you notice that when the key being put is longer than `2**K - 1`, where K is the key/path length configured for the trie, the put *succeeds* but then the retrieved leaf has a key that is different from the original. This is due to [1](https://github.com/BumblebeeBat/MerkleTrie/blob/a80b422c9fe0f3bbce1dbad6c32111c7e54883f0/src/leaf.erl#L11) and [2](https://github.com/BumblebeeBat/MerkleTrie/blob/a80b422c9fe0f3bbce1dbad6c32111c7e54883f0/src/leaf.erl#L33) - for example in an Erlang shell:
```
1> <<4:2>>.
<<0:2>>
```