### PR TITLE
AE-33 Plant type specs

### DIFF
--- a/src/cfg.erl
+++ b/src/cfg.erl
@@ -1,12 +1,30 @@
 -module(cfg).
 -compile(export_all).
--record(cfg, {path, value, id, meta, hash_size}). 
+-export_type([cfg/0,path/0,value/0,id/0,meta/0,hash_size/0]).
+-record(cfg, { path :: path()
+	     , value :: value()
+	     , id :: id()
+	     , meta :: meta()
+	     , hash_size :: hash_size()
+	     }).
+-opaque cfg() :: #cfg{}.
+-type path() :: pos_integer().
+-type value() :: non_neg_integer().
+-type id() :: atom().
+-type meta() :: non_neg_integer().
+-type hash_size() :: pos_integer().
+-spec new(path(), value(), id(), meta(), hash_size()) -> cfg().
 new(P, V, ID, M, H) -> #cfg{path = P, value = V, 
 			    id = ID, meta = M,
 			    hash_size = H }.
+-spec path(cfg()) -> path().
 path(X) -> X#cfg.path. %how many bytes to store the path (defaul is 5)
+-spec value(cfg()) -> value().
 value(X) -> X#cfg.value.%how many bytes to store the value.
+-spec meta(cfg()) -> meta().
 meta(X) -> X#cfg.meta. %how many bytes to store the meta data that isn't hashed into the merkle tree.
 leaf(X) -> path(X) + value(X) + meta(X).
+-spec id(cfg()) -> id().
 id(X) -> X#cfg.id.
+-spec hash_size(cfg()) -> hash_size().
 hash_size(X) -> X#cfg.hash_size.

--- a/src/delete.erl
+++ b/src/delete.erl
@@ -1,6 +1,7 @@
 -module(delete).
 -export([delete/3]).
 
+-spec delete(leaf:key(), stem:stem_p(), cfg:cfg()) -> stem:stem_p().
 delete(ID, Root, CFG) ->
     Path = leaf:path_maker(ID, CFG),
     Branch = store:get_branch(Path, 0, Root, [], CFG),

--- a/src/garbage.erl
+++ b/src/garbage.erl
@@ -6,6 +6,7 @@ garbage_leaves(KeeperLeaves, CFG) ->
     delete_stuff(0, KL, ids:leaf(CFG)),
     delete_stuff(0, [0|KeeperStems], ids:stem(CFG)),
     ok.
+-spec garbage([stem:stem_p()], cfg:cfg()) -> ok.
 garbage(KeeperRoots, CFG) ->
     {KeeperStems, KeeperLeaves} = keepers(KeeperRoots, CFG),
     %io:fwrite(integer_to_list(length(KeeperLeaves))),

--- a/src/get.erl
+++ b/src/get.erl
@@ -1,7 +1,13 @@
 -module(get).
 -export([get/3]).
+-export_type([proof/0]).
 
-get(Path, Root, CFG) -> %returns {RootHash, Value, Proof}
+-type proof() :: [stem:hashes(), ...].
+
+-spec get(leaf:path(), stem:stem_p(), cfg:cfg()) ->
+		 {RootHash::stem:hash(), Value, proof()}
+		     when Value :: empty | leaf:leaf().
+get(Path, Root, CFG) ->
     S = stem:get(Root, CFG),
     H = stem:hash(S, CFG),
     case get2(Path, S, [stem:hashes(S)], CFG) of

--- a/src/get.erl
+++ b/src/get.erl
@@ -2,7 +2,7 @@
 -export([get/3]).
 -export_type([proof/0]).
 
--type proof() :: [stem:hashes(), ...].
+-type proof() :: [stem:hashes(), ...]. % the last element is the 16-hashes-tuple contained in the root
 
 -spec get(leaf:path(), stem:stem_p(), cfg:cfg()) ->
 		 {RootHash::stem:hash(), Value, proof()}

--- a/src/leaf.erl
+++ b/src/leaf.erl
@@ -1,7 +1,7 @@
 -module(leaf).
 -export([new/4, key/1, value/1, meta/1, path/2, path_maker/2, hash/2, put/2, get/2, serialize/2, deserialize/2]).
--record(leaf, {key = 0, value = 0, 
-	       meta = 0}). %meta is data we want to remember that doesn't get hashed into the merkle tree.
+-record(leaf, {key, value,
+	       meta}). %meta is data we want to remember that doesn't get hashed into the merkle tree.
 serialize(X, CFG) ->
     P = cfg:path(CFG) * 8,
     M = cfg:meta(CFG) * 8,

--- a/src/leaf.erl
+++ b/src/leaf.erl
@@ -1,7 +1,18 @@
 -module(leaf).
 -export([new/4, key/1, value/1, meta/1, path/2, path_maker/2, hash/2, put/2, get/2, serialize/2, deserialize/2]).
--record(leaf, {key, value,
-	       meta}). %meta is data we want to remember that doesn't get hashed into the merkle tree.
+-export_type([leaf/0,key/0,value/0,meta/0,leaf_p/0,path/0]).
+-record(leaf, { key :: key()
+	      , value :: value()
+	      , meta :: meta() %meta is data we want to remember that doesn't get hashed into the merkle tree.
+	      }).
+-opaque leaf() :: #leaf{}.
+-type key() :: non_neg_integer().
+-type value() :: binary().
+-type meta() :: non_neg_integer().
+-opaque leaf_p() :: non_neg_integer().
+-type path() :: path(cfg:path()).
+-type path(_CfgPathSizeBytes) :: non_empty_binary(). % non-empty because configured path size positive
+-type non_empty_binary() :: <<_:8, _:_*8>>.
 serialize(X, CFG) ->
     P = cfg:path(CFG) * 8,
     M = cfg:meta(CFG) * 8,
@@ -19,6 +30,7 @@ deserialize(A, CFG) ->
       Meta:MS,
       Value:L>> = A,
     #leaf{key = Key, value = <<Value:L>>, meta = Meta}. 
+-spec new(key(), value(), meta(), cfg:cfg()) -> leaf().
 new(Key, Value, Meta, CFG) ->
     {ok, _} = {check_key(Key, cfg:path(CFG)), Key},
     L = cfg:value(CFG) * 8,
@@ -33,20 +45,25 @@ check_key(Key, _) when is_integer(Key) ->
 check_key(_, _) ->
     {error, key_not_integer}.
 key(L) -> L#leaf.key.
+-spec path(leaf(), cfg:cfg()) -> path().
 path(L, CFG) ->
     K = key(L),
     path_maker(K, CFG).
+-spec path_maker(key(), cfg:cfg()) -> path().
 path_maker(K, CFG) ->
     T = cfg:path(CFG)*8,
     flip_bytes(<<K:T>>).
 value(L) -> L#leaf.value.
 meta(X) -> X#leaf.meta.
+-spec put(leaf(), cfg:cfg()) -> leaf_p().
 put(Leaf, CFG) ->
     dump:put(serialize(Leaf, CFG), 
 	     ids:leaf(CFG)).
+-spec get(leaf_p(), cfg:cfg()) -> leaf().
 get(Pointer, CFG) ->
     L = dump:get(Pointer, ids:leaf(CFG)),
     deserialize(L, CFG).
+-spec hash(leaf(), cfg:cfg()) -> stem:hash().
 hash(L, CFG) ->   
     P = cfg:path(CFG) * 8,
     HS = cfg:hash_size(CFG),

--- a/src/stem.erl
+++ b/src/stem.erl
@@ -108,7 +108,9 @@ empty_hashes(CFG) ->
      <<0:X>>,<<0:X>>,<<0:X>>,<<0:X>>,
      <<0:X>>,<<0:X>>,<<0:X>>,<<0:X>>}.
 
--spec hash(Hashes::any(), cfg:cfg()) -> hash().
+-spec hash(Hashes, cfg:cfg()) -> hash() when
+      Hashes :: SerializedStem | hashes() | stem(),
+      SerializedStem :: binary().
 hash(S, CFG) when is_binary(S) ->
     hash(deserialize(S, CFG), CFG);
 hash(S, CFG) when is_tuple(S) and (size(S) == 16)->    

--- a/src/store.erl
+++ b/src/store.erl
@@ -2,7 +2,7 @@
 -export([store/3, store/5, get_branch/5, store_branch/6]).
 -export_type([branch/0, nonempty_branch/0]).
 
--type branch() :: [stem:stem()]. % head is most distant from root i.e. closest to leaf (if any)
+-type branch() :: [stem:stem()]. % first element is most distant from root i.e. closest to leaf (if any)
 -type nonempty_branch() :: [stem:stem(), ...].
 
 store(Leaf, Hash, Proof, Root, CFG) -> %this restores information to the merkle trie that had been garbage collected.

--- a/src/store.erl
+++ b/src/store.erl
@@ -70,23 +70,26 @@ get_branch(Path, N, Parent, Trail, CFG) ->
 		    {Leaf, Pointer, RP}
 	    end
     end.
-store_branch([], Path, _, Pointer, _, CFG) ->
+store_branch(Branch = [_|_], Path, Type, Pointer, Hash, CFG) when Type =:= 0;
+								  Type =:= 2 ->
+    store_branch_internal(Branch, Path, Type, Pointer, Hash, CFG).
+store_branch_internal([], Path, _, Pointer, _, CFG) ->
     %Instead of getting the thing, we can build it up while doing store.
     {Hash, _, Proof} = get:get(Path, Pointer, CFG),
     {Hash, Pointer, Proof};
 
     %case get:get(Path, Pointer, CFG) of
 	%{Hash, _, Proof} -> {Hash, Pointer, Proof};
-	%empty -> store_branch([], Path, 0, Pointer, 0, CFG)
+	%empty -> store_branch_internal([], Path, 0, Pointer, 0, CFG)
     %end;
-store_branch([B|Branch], Path, Type, Pointer, Hash, CFG) ->
+store_branch_internal([B|Branch], Path, Type, Pointer, Hash, CFG) ->
     S = length(Branch),
     NN = 4*S,
     <<_:NN, A:4, _/bitstring>> = Path,
     S1 = stem:add(B, A, Type, Pointer, Hash),
     Loc = stem:put(S1, CFG),
     SH = stem:hash(S1, CFG),
-    store_branch(Branch, Path, 1, Loc, SH, CFG).
+    store_branch_internal(Branch, Path, 1, Loc, SH, CFG).
 %add(L) -> add(L, 0).
 %add([], X) -> X;
 %add([H|T], X) -> add(T, H+X).

--- a/src/store.erl
+++ b/src/store.erl
@@ -1,5 +1,9 @@
 -module(store).
 -export([store/3, store/5, get_branch/5, store_branch/6]).
+-export_type([branch/0, nonempty_branch/0]).
+
+-type branch() :: [stem:stem()]. % head is most distant from root i.e. closest to leaf (if any)
+-type nonempty_branch() :: [stem:stem(), ...].
 
 store(Leaf, Hash, Proof, Root, CFG) -> %this restores information to the merkle trie that had been garbage collected.
 
@@ -31,7 +35,11 @@ proof2branch([H|T], Type, Pointer, Hash, Path, CFG) ->
     [S|proof2branch(T, 1, NewPointer, NewHash, NewPath, CFG)].
     
     
-store(Leaf, Root, CFG) -> %returns {RootHash, RootPointer, Proof}
+-spec store(leaf:leaf(), stem:stem_p(), cfg:cfg()) ->
+		   {RootHash, RootPointer, get:proof()}
+		       when RootHash :: stem:hash(),
+			    RootPointer :: stem:stem_p().
+store(Leaf, Root, CFG) ->
     %we could make it faster if the input was like [{Key1, Value1}, {Key2, Value2}...]
     LPointer = leaf:put(Leaf, CFG),
     LH = leaf:hash(Leaf, CFG),
@@ -48,6 +56,13 @@ store(Leaf, Root, CFG) -> %returns {RootHash, RootPointer, Proof}
 		Branch
     end,
     store_branch(B, P, 2, LPointer, LH, CFG).
+-type path_nibble_index() :: path_nibble_index(cfg:path()).
+-type path_nibble_index(_CfgPathSizeBytes) :: non_neg_integer(). % 0..((cfg:path() * 2) - 1)
+-spec get_branch(Path::leaf:path(), StartInPath::path_nibble_index(),
+		 stem:stem_p(), branch(), cfg:cfg()) ->
+			{leaf:leaf(), leaf:leaf_p(), % leaf (and corresponding pointer) at returned branch and containing path different from the specified one
+			 Branch::nonempty_branch()} |
+			nonempty_branch(). % branch either (1) without leaf or (2) with leaf containing specified path
 get_branch(Path, N, Parent, Trail, CFG) ->
     %gather the branch as it currently looks.
     NN = 4*N,
@@ -70,6 +85,14 @@ get_branch(Path, N, Parent, Trail, CFG) ->
 		    {Leaf, Pointer, RP}
 	    end
     end.
+-spec store_branch(nonempty_branch(), leaf:path(),
+		   stem:leaf_t(), leaf:leaf_p(), stem:hash(),
+		   cfg:cfg()) -> Result when
+      Result :: {RootHash::stem:hash(), Root::stem:stem_p(), get:proof()};
+		  (nonempty_branch(), leaf:path(),
+		   stem:empty_t(), stem:empty_p(), stem:hash(),
+		   cfg:cfg()) -> Result when
+      Result :: {RootHash::stem:hash(), Root::stem:stem_p(), get:proof()}.
 store_branch(Branch = [_|_], Path, Type, Pointer, Hash, CFG) when Type =:= 0;
 								  Type =:= 2 ->
     store_branch_internal(Branch, Path, Type, Pointer, Hash, CFG).

--- a/src/trie.erl
+++ b/src/trie.erl
@@ -52,11 +52,17 @@ cfg(ID) when is_atom(ID) ->
     gen_server:call({global, ids:main_id(ID)}, cfg).
 root_hash(ID, RootPointer) when is_atom(ID) ->
     gen_server:call({global, ids:main_id(ID)}, {root_hash, RootPointer}).
+-spec put(leaf:key(), leaf:value(), leaf:meta(), stem:stem_p(), atom()) ->
+		 stem:stem_p().
 put(Key, Value, Meta, Root, ID) ->
     gen_server:call({global, ids:main_id(ID)}, {put, Key, Value, Meta, Root}).
+-spec get(leaf:key(), stem:stem_p(), atom()) ->
+		 {stem:hash(), empty | leaf:leaf(), get:proof()}.
 get(Key, Root, ID) -> gen_server:call({global, ids:main_id(ID)}, {get, Key, Root}).
 get_all(Root, ID) -> gen_server:call({global, ids:main_id(ID)}, {get_all, Root}).
+-spec delete(leaf:key(), stem:stem_p(), atom()) -> stem:stem_p().
 delete(Key, Root, ID) -> gen_server:call({global, ids:main_id(ID)}, {delete, Key, Root}).
+-spec garbage([stem:stem_p()], atom()) -> ok.
 garbage(Keepers, ID) -> 
     %io:fwrite("trie garbage \n"),
     gen_server:cast({global, ids:main_id(ID)}, {garbage, Keepers}).

--- a/src/verify.erl
+++ b/src/verify.erl
@@ -1,5 +1,7 @@
 -module(verify).
 -export([proof/4]).
+
+-spec proof(stem:hash(), leaf:leaf(), get:proof(), cfg:cfg()) -> boolean().
 proof(RootHash, L, Proof, CFG) ->
     [H|F] = flip(Proof),
     SH = stem:hash(H, CFG),


### PR DESCRIPTION
Depends on #10.

I consider these type specifications good enough as a first iteration from a documentation point of view, ~but~ and I did not yet triage the resulting Dialyzer warnings ~so~ anyway I suggest ~*not* to merge this PR yet~ to merge this PR as it is.

----
Dialyzer warnings I get as of d23392f :
```
src/garbage.erl
  19: The call leaf:get(K::stem:stem_p(), CFG::any()) does not have an opaque term of type leaf:leaf_p() as 1st argument
  47: The attempt to match a term of type stem:stem() against the pattern 'error' breaks the opaqueness of the term
  87: The call garbage:delete_stuff(S::integer(), 1, Keepers::[stem:stem_p()], Id::atom()) does not have a term of type 0 | leaf:leaf_p() | stem:stem_p() (with opaque subterms) as 2nd argument
  90: The call garbage:delete_stuff(S::integer(), 1, Keepers::[stem:stem_p()], Id::atom()) does not have a term of type 0 | leaf:leaf_p() | stem:stem_p() (with opaque subterms) as 2nd argument

src/get.erl
  10: Function get/3 has no local return
  12: The call stem:hash(S::stem:stem(), CFG::cfg:cfg()) contains an opaque term as 1st argument when terms of different types are expected in these positions
  17: Function get2/4 will never be called

src/stem.erl
 138: Call to missing or unexported function cfg:new/4

src/store.erl
   8: Function store/5 has no local return
  20: Function combine_branches/3 has no local return
  20: The pattern <_, X, []> can never match the type <<<_:8,_:_*8>>,[],[stem:stem(),...] | {leaf:leaf(),leaf:leaf_p() | stem:stem_p(),[stem:stem(),...]}>
  21: The pattern <<<N:4/integer-unit:1,Path/binary-unit:1>>, [Sa | A], [Sb | B]> can never match the type <<<_:8,_:_*8>>,[],[stem:stem(),...] | {leaf:leaf(),leaf:leaf_p() | stem:stem_p(),[stem:stem(),...]}>
  23: Function combine_stems/3 will never be called
  34: The call stem:hash(S::stem:stem(), CFG::cfg:cfg()) contains an opaque term as 1st argument when terms of different types are expected in these positions
  42: Function store/3 has no local return
  96: Function store_branch/6 has no local return
  99: Function store_branch_internal/6 has no local return
  99: The pattern <[], Path, _, Pointer, _, CFG> can never match the type <nonempty_maybe_improper_list(),_,0 | 2,_,_,_>
 114: The call stem:hash(S1::stem:stem(), CFG::cfg:cfg()) contains an opaque term as 1st argument when terms of different types are expected in these positions

src/test_trie.erl
   6: Function test/0 has no local return
  28: The call leaf:serialize(LeafAB::leaf:leaf(), CFG::cfg:cfg()) contains an opaque term as 1st argument when terms of different types are expected in these positions
  87: The call store:store(Leaf::leaf:leaf(), Loc::0, CFG::cfg:cfg()) does not have an opaque term of type stem:stem_p() as 2nd argument
 148: The call store:store(Leaf1::leaf:leaf(), Root0::0, CFG::cfg:cfg()) does not have an opaque term of type stem:stem_p() as 2nd argument
 183: The call store:store(Leafa::leaf:leaf(), Root0::0, CFG::cfg:cfg()) does not have an opaque term of type stem:stem_p() as 2nd argument
 219: The call store:store(Leaf1::leaf:leaf(), Root0::0, CFG::cfg:cfg()) does not have an opaque term of type stem:stem_p() as 2nd argument
 231: The call trie:put(Key::1, V1::<<_:16>>, Meta::0, Root::0, 'trie01') does not have an opaque term of type stem:stem_p() as 4th argument
 240: The call stem:get(0, CFG::any()) does not have an opaque term of type stem:stem_p() as 1st argument
 258: Function test3a/3 has no local return
 258: The pattern <0, _, L> can never match the type <1000,1000,0>
 267: The call trie:put(1, <<_:16>>, Meta::0, Loc::0, 'trie01') does not have an opaque term of type stem:stem_p() as 4th argument
 269: Function test3b/3 will never be called

src/trie.erl
   4: Function init/1 has no local return
   5: The attempt to match a term of type stem:stem_p() against the pattern 0 breaks the opaqueness of the term
  32: The call leaf:key(L::'empty' | leaf:leaf()) contains an opaque term as 1st argument when a structured term of type {'leaf',non_neg_integer(),binary(),non_neg_integer()} is expected
  47: The call stem:hash(S::stem:stem(), CFG::cfg:cfg()) contains an opaque term as 1st argument when terms of different types are expected in these positions
```