### PR TITLE
AE-134 Smoke test load test scripts on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,22 @@ otp_release:
   - 19.3.6.1
   - 18.3
 before_install:
-  - ./ci before_install "${TRAVIS_BUILD_DIR:?}"
+  - ./ci before_install "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
 install:
-  - ./ci install "${TRAVIS_BUILD_DIR:?}"
+  - ./ci install "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
 before_script:
-  - ./ci before_script "${TRAVIS_BUILD_DIR:?}"
+  - ./ci before_script "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
 script:
-  - ./ci script "${TRAVIS_BUILD_DIR:?}"
-after_success:
-  - ./ci after_success "${TRAVIS_BUILD_DIR:?}"
+  - ./ci script "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
+matrix:
+  allow_failures:
+    - env: JOB=dialyzer
+    - env: JOB=xref
+  fast_finish: true
+env:
+  - JOB=eunit
+  - JOB=dialyzer
+  - JOB=xref
 cache:
   directories:
     - .plt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
-sudo: false
+dist: trusty
+sudo: required
 language: erlang
 otp_release:
   - 19.3.6.1
   - 18.3
 before_install:
+  - if test smokeloadtest = "${JOB:?}"; then sudo apt-get -qq update && sudo apt-get install -y r-cran-plyr r-cran-ggplot2; fi
   - ./ci before_install "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
 install:
   - ./ci install "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
@@ -12,6 +14,9 @@ before_script:
 script:
   - ./ci script "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
 matrix:
+  exclude:
+    - otp_release: 18.3
+      env: JOB=smokeloadtest
   allow_failures:
     - env: JOB=dialyzer
     - env: JOB=xref
@@ -20,6 +25,7 @@ env:
   - JOB=eunit
   - JOB=dialyzer
   - JOB=xref
+  - JOB=smokeloadtest
 cache:
   directories:
     - .plt

--- a/ci
+++ b/ci
@@ -2,28 +2,38 @@
 
 set -ev # Ref https://docs.travis-ci.com/user/customizing-the-build/#Implementing-Complex-Build-Steps
 
-case "${1:?}" in
-    before_install)
+case "${1:?}"-"${2:?}" in
+    before_install-*)
         ## Travis CI does not support rebar3 yet. See https://github.com/travis-ci/travis-ci/issues/6506#issuecomment-275189490
-        BuildDir="${2:?}"
+        BuildDir="${3:?}"
         curl -fL -o "${BuildDir:?}"/rebar3 https://github.com/erlang/rebar3/releases/download/3.4.1/rebar3
         chmod +x "${BuildDir:?}"/rebar3
         ;;
-    install)
-        BuildDir="${2:?}"
+    install-dialyzer)
+        BuildDir="${3:?}"
         ( cd "${BuildDir:?}" && ./rebar3 tree; )
         ( cd "${BuildDir:?}" && ./rebar3 dialyzer -u true -s false; )
         ;;
-    before_script)
-        BuildDir="${2:?}"
+    install-*)
+        true
+        ;;
+    before_script-eunit)
+        BuildDir="${3:?}"
         mkdir "${BuildDir:?}"/data
         ;;
-    script)
-        BuildDir="${2:?}"
+    before_script-*)
+        true
+        ;;
+    script-eunit)
+        BuildDir="${3:?}"
         ( cd "${BuildDir:?}" && ./rebar3 eunit; )
         ;;
-    after_success)
-        BuildDir="${2:?}"
+    script-dialyzer)
+        BuildDir="${3:?}"
         ( cd "${BuildDir:?}" && ./rebar3 dialyzer; )
+        ;;
+    script-xref)
+        BuildDir="${3:?}"
+        ( cd "${BuildDir:?}" && ./rebar3 xref; )
         ;;
 esac

--- a/ci
+++ b/ci
@@ -14,12 +14,26 @@ case "${1:?}"-"${2:?}" in
         ( cd "${BuildDir:?}" && ./rebar3 tree; )
         ( cd "${BuildDir:?}" && ./rebar3 dialyzer -u true -s false; )
         ;;
+    install-smokeloadtest)
+        BuildDir="${3:?}"
+        WorkDir="${BuildDir:?}"/tmp
+        mkdir "${WorkDir:?}" ## create working folder
+        ( cd "${WorkDir:?}" && git clone https://github.com/mrallen1/basho_bench.git && cd basho_bench && git checkout c92c71c09b17f5f2c983a31d2a6ec2db40de9bfe && PATH="${BuildDir:?}":"$PATH" make && file basho_bench; ) ## build load test tool "basho_bench"
+        mkdir "${WorkDir:?}"/R_libs ## create location for R libraries used by graph generation in basho_bench
+        ;;
     install-*)
         true
         ;;
     before_script-eunit)
         BuildDir="${3:?}"
         mkdir "${BuildDir:?}"/data
+        ;;
+    before_script-smokeloadtest)
+        BuildDir="${3:?}"
+        WorkDir="${BuildDir:?}"/tmp
+        ( cd "${BuildDir:?}" && ./rebar3 compile && ls "${BuildDir:?}"/_build/default/lib; ) ## compile trie library
+        mkdir "${WorkDir:?}"/ebin ## create location for trie library-specific module for basho_bench
+        mkdir "${WorkDir:?}"/basho_bench/data ## create location for data persisted by trie library
         ;;
     before_script-*)
         true
@@ -35,5 +49,13 @@ case "${1:?}"-"${2:?}" in
     script-xref)
         BuildDir="${3:?}"
         ( cd "${BuildDir:?}" && ./rebar3 xref; )
+        ;;
+    script-smokeloadtest)
+        BuildDir="${3:?}"
+        WorkDir="${BuildDir:?}"/tmp
+        erlc -o "${WorkDir:?}"/ebin "${BuildDir:?}"/scripts/load_test/basho_bench_driver_trie.erl && file "${WorkDir:?}"/ebin/basho_bench_driver_trie.beam ## compile trie library-specific module for basho_bench
+        sed -e "s|CODE_PATHS_AS_STRING_LIST|[\"${WorkDir:?}/ebin\", \"${BuildDir:?}/_build/default/lib/dump/ebin\", \"${BuildDir:?}/_build/default/lib/encrypter/ebin\", \"${BuildDir:?}/_build/default/lib/pink_hash/ebin\", \"${BuildDir:?}/_build/default/lib/trie/ebin\"]|" < "${BuildDir:?}"/scripts/load_test/trie.config.template > "${WorkDir:?}"/trie.config && cat "${WorkDir:?}"/trie.config ## instantiate load test configuration and show it
+        ( cd "${WorkDir:?}"/basho_bench && ./basho_bench --results-dir ./tests "${WorkDir:?}"/trie.config; ) ## run load test
+        ( cd "${WorkDir:?}"/basho_bench && ( R_LIBS="${WorkDir:?}"/R_libs && export R_LIBS && make results; ) && ( cd ./tests/current && ls -l; ) && file ./tests/current/summary.png; ) ## generate load test results graph
         ;;
 esac

--- a/ci
+++ b/ci
@@ -6,7 +6,7 @@ case "${1:?}"-"${2:?}" in
     before_install-*)
         ## Travis CI does not support rebar3 yet. See https://github.com/travis-ci/travis-ci/issues/6506#issuecomment-275189490
         BuildDir="${3:?}"
-        curl -fL -o "${BuildDir:?}"/rebar3 https://github.com/erlang/rebar3/releases/download/3.4.1/rebar3
+        curl -fL -o "${BuildDir:?}"/rebar3 https://github.com/erlang/rebar3/releases/download/3.4.2/rebar3
         chmod +x "${BuildDir:?}"/rebar3
         ;;
     install-dialyzer)

--- a/scripts/load_test/basho_bench_driver_trie.erl
+++ b/scripts/load_test/basho_bench_driver_trie.erl
@@ -1,0 +1,47 @@
+-module(basho_bench_driver_trie).
+
+-export([new/1,
+         run/4]).
+
+%% Macros compatible with header `basho_bench.hrl` - in order not to
+%% require including it for compiling this module:
+-define(INFO(Str, Args), error_logger:info_msg(Str, Args)).
+
+-record(state, {
+          trie_id,
+          root
+         }).
+
+new({_,_,Id}) ->
+    TrieId = basho_bench_config:get(trie_id),
+    KeySizeBytes = basho_bench_config:get(trie_key_size_bytes),
+    ValueSizeBytes = basho_bench_config:get(trie_value_size_bytes),
+    MetaSizeBytes = 0 = basho_bench_config:get(trie_meta_size_bytes),
+    HashSizeBytes = basho_bench_config:get(trie_hash_size_bytes),
+    Amount = basho_bench_config:get(trie_amount),
+    Mode = basho_bench_config:get(trie_mode),
+    {ok, TrieSupPid} =
+        trie_sup:start_link( %% TODO review linking
+          KeySizeBytes,
+          ValueSizeBytes,
+          TrieId,
+          Amount,
+          MetaSizeBytes,
+          HashSizeBytes,
+          Mode),
+    ?INFO("Worker ~p using trie with id ~p and sup ~p.\n", [Id, TrieId, TrieSupPid]),
+    Root = basho_bench_config:get(trie_initial_empty_root),
+    {[], _} = {trie:get_all(Root, TrieId), {{worker_id, Id}, {trie_initial_allegedly_empy_root, Root}}},
+    State = #state{trie_id = TrieId, root = Root},
+    {ok, State}.
+
+run(get, KeyGen, _ValueGen, State = #state{}) ->
+    Key = KeyGen(),
+    case trie:get(Key, State#state.root, State#state.trie_id) of
+        {_, empty, _} ->
+            {ok, State};
+        {_, _, _} ->
+            {ok, State};
+        Unknown ->
+            {error, Unknown}
+    end.

--- a/scripts/load_test/trie.config.template
+++ b/scripts/load_test/trie.config.template
@@ -1,0 +1,24 @@
+%% -*- mode: erlang;-*-
+{mode, {rate, 1}}. %% `max`, i.e. as many ops/s as possible, or `{rate, N}`, i.e. N ops/s, with exponentially distributed interarrival times.
+{concurrent, 1}. %% number of concurrent workers
+{duration, 1}. %% minutes
+
+{code_paths, CODE_PATHS_AS_STRING_LIST}. %% Paths of additional Erlang code e.g. `{code_paths, ["./foo/ebin", "./bar/ebin"]}.`
+
+{driver, basho_bench_driver_trie}.
+
+{operations, [{get, 1}]}. %% weighted list of operations the driver will run
+
+{key_generator, {uniform_int, 100}}. %% 1..N
+{value_generator, {fixed_bin, 2}}. %% random binary of size N bytes
+
+%% Driver-specific configuration below.
+{trie_id, trieLoadTest}.
+{trie_key_size_bytes, 9}.
+{trie_value_size_bytes, 2}.
+{trie_meta_size_bytes, 0}.
+{trie_hash_size_bytes, 12}.
+{trie_amount, 1000000}.
+{trie_mode, hd}.
+{trie_initial_empty_root, 0}.
+%% TODO parametrize trie storage location. E.g. `{trie_dir, "./tmp/trie.bench"}.`


### PR DESCRIPTION
A sample run on Travis CI for d6cfe65 is available at https://travis-ci.org/lucafavatella/MerkleTrie/builds/256032435
Please refer to the commit messages for details on how to quickly reproduce this locally.

This PR is ready for merge but I envisage it not to close AE-134 yet - I plan to add other operations to the scripts e.g. trie:put first.