### PR TITLE
AE-134 Primitive load test scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,22 @@ otp_release:
   - 19.3.6.1
   - 18.3
 before_install:
-  - ./ci before_install "${TRAVIS_BUILD_DIR:?}"
+  - ./ci before_install "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
 install:
-  - ./ci install "${TRAVIS_BUILD_DIR:?}"
+  - ./ci install "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
 before_script:
-  - ./ci before_script "${TRAVIS_BUILD_DIR:?}"
+  - ./ci before_script "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
 script:
-  - ./ci script "${TRAVIS_BUILD_DIR:?}"
-after_success:
-  - ./ci after_success "${TRAVIS_BUILD_DIR:?}"
+  - ./ci script "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
+matrix:
+  allow_failures:
+    - env: JOB=dialyzer
+    - env: JOB=xref
+  fast_finish: true
+env:
+  - JOB=eunit
+  - JOB=dialyzer
+  - JOB=xref
 cache:
   directories:
     - .plt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
-sudo: false
+dist: trusty
+sudo: required
 language: erlang
 otp_release:
   - 19.3.6.1
   - 18.3
 before_install:
+  - if test smokeloadtest = "${JOB:?}"; then sudo apt-get -qq update && sudo apt-get install -y r-cran-plyr r-cran-ggplot2; fi
   - ./ci before_install "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
 install:
   - ./ci install "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
@@ -12,6 +14,9 @@ before_script:
 script:
   - ./ci script "${JOB:?}" "${TRAVIS_BUILD_DIR:?}"
 matrix:
+  exclude:
+    - otp_release: 18.3
+      env: JOB=smokeloadtest
   allow_failures:
     - env: JOB=dialyzer
     - env: JOB=xref
@@ -20,6 +25,7 @@ env:
   - JOB=eunit
   - JOB=dialyzer
   - JOB=xref
+  - JOB=smokeloadtest
 cache:
   directories:
     - .plt

--- a/ci
+++ b/ci
@@ -2,28 +2,38 @@
 
 set -ev # Ref https://docs.travis-ci.com/user/customizing-the-build/#Implementing-Complex-Build-Steps
 
-case "${1:?}" in
-    before_install)
+case "${1:?}"-"${2:?}" in
+    before_install-*)
         ## Travis CI does not support rebar3 yet. See https://github.com/travis-ci/travis-ci/issues/6506#issuecomment-275189490
-        BuildDir="${2:?}"
+        BuildDir="${3:?}"
         curl -fL -o "${BuildDir:?}"/rebar3 https://github.com/erlang/rebar3/releases/download/3.4.1/rebar3
         chmod +x "${BuildDir:?}"/rebar3
         ;;
-    install)
-        BuildDir="${2:?}"
+    install-dialyzer)
+        BuildDir="${3:?}"
         ( cd "${BuildDir:?}" && ./rebar3 tree; )
         ( cd "${BuildDir:?}" && ./rebar3 dialyzer -u true -s false; )
         ;;
-    before_script)
-        BuildDir="${2:?}"
+    install-*)
+        true
+        ;;
+    before_script-eunit)
+        BuildDir="${3:?}"
         mkdir "${BuildDir:?}"/data
         ;;
-    script)
-        BuildDir="${2:?}"
+    before_script-*)
+        true
+        ;;
+    script-eunit)
+        BuildDir="${3:?}"
         ( cd "${BuildDir:?}" && ./rebar3 eunit; )
         ;;
-    after_success)
-        BuildDir="${2:?}"
+    script-dialyzer)
+        BuildDir="${3:?}"
         ( cd "${BuildDir:?}" && ./rebar3 dialyzer; )
+        ;;
+    script-xref)
+        BuildDir="${3:?}"
+        ( cd "${BuildDir:?}" && ./rebar3 xref; )
         ;;
 esac

--- a/ci
+++ b/ci
@@ -14,12 +14,26 @@ case "${1:?}"-"${2:?}" in
         ( cd "${BuildDir:?}" && ./rebar3 tree; )
         ( cd "${BuildDir:?}" && ./rebar3 dialyzer -u true -s false; )
         ;;
+    install-smokeloadtest)
+        BuildDir="${3:?}"
+        WorkDir="${BuildDir:?}"/tmp
+        mkdir "${WorkDir:?}" ## create working folder
+        ( cd "${WorkDir:?}" && git clone https://github.com/mrallen1/basho_bench.git && cd basho_bench && git checkout c92c71c09b17f5f2c983a31d2a6ec2db40de9bfe && PATH="${BuildDir:?}":"$PATH" make && file basho_bench; ) ## build load test tool "basho_bench"
+        mkdir "${WorkDir:?}"/R_libs ## create location for R libraries used by graph generation in basho_bench
+        ;;
     install-*)
         true
         ;;
     before_script-eunit)
         BuildDir="${3:?}"
         mkdir "${BuildDir:?}"/data
+        ;;
+    before_script-smokeloadtest)
+        BuildDir="${3:?}"
+        WorkDir="${BuildDir:?}"/tmp
+        ( cd "${BuildDir:?}" && ./rebar3 compile && ls "${BuildDir:?}"/_build/default/lib; ) ## compile trie library
+        mkdir "${WorkDir:?}"/ebin ## create location for trie library-specific module for basho_bench
+        mkdir "${WorkDir:?}"/basho_bench/data ## create location for data persisted by trie library
         ;;
     before_script-*)
         true
@@ -35,5 +49,13 @@ case "${1:?}"-"${2:?}" in
     script-xref)
         BuildDir="${3:?}"
         ( cd "${BuildDir:?}" && ./rebar3 xref; )
+        ;;
+    script-smokeloadtest)
+        BuildDir="${3:?}"
+        WorkDir="${BuildDir:?}"/tmp
+        erlc -o "${WorkDir:?}"/ebin "${BuildDir:?}"/scripts/load_test/basho_bench_driver_trie.erl && file "${WorkDir:?}"/ebin/basho_bench_driver_trie.beam ## compile trie library-specific module for basho_bench
+        sed -e "s|CODE_PATHS_AS_STRING_LIST|[\"${WorkDir:?}/ebin\", \"${BuildDir:?}/_build/default/lib/dump/ebin\", \"${BuildDir:?}/_build/default/lib/encrypter/ebin\", \"${BuildDir:?}/_build/default/lib/pink_hash/ebin\", \"${BuildDir:?}/_build/default/lib/trie/ebin\"]|" < "${BuildDir:?}"/scripts/load_test/trie.config.template > "${WorkDir:?}"/trie.config && cat "${WorkDir:?}"/trie.config ## instantiate load test configuration and show it
+        ( cd "${WorkDir:?}"/basho_bench && ./basho_bench --results-dir ./tests "${WorkDir:?}"/trie.config; ) ## run load test
+        ( cd "${WorkDir:?}"/basho_bench && ( R_LIBS="${WorkDir:?}"/R_libs && export R_LIBS && make results; ) && ( cd ./tests/current && ls -l; ) && file ./tests/current/summary.png; ) ## generate load test results graph
         ;;
 esac

--- a/ci
+++ b/ci
@@ -6,7 +6,7 @@ case "${1:?}"-"${2:?}" in
     before_install-*)
         ## Travis CI does not support rebar3 yet. See https://github.com/travis-ci/travis-ci/issues/6506#issuecomment-275189490
         BuildDir="${3:?}"
-        curl -fL -o "${BuildDir:?}"/rebar3 https://github.com/erlang/rebar3/releases/download/3.4.1/rebar3
+        curl -fL -o "${BuildDir:?}"/rebar3 https://github.com/erlang/rebar3/releases/download/3.4.2/rebar3
         chmod +x "${BuildDir:?}"/rebar3
         ;;
     install-dialyzer)

--- a/scripts/load_test/basho_bench_driver_trie.erl
+++ b/scripts/load_test/basho_bench_driver_trie.erl
@@ -5,7 +5,10 @@
 
 %% Macros compatible with header `basho_bench.hrl` - in order not to
 %% require including it for compiling this module:
+-define(DEBUG(Str, Args), error_logger:info_msg(Str, Args)).
 -define(INFO(Str, Args), error_logger:info_msg(Str, Args)).
+-define(WARN(Str, Args), error_logger:warning_msg(Str, Args)).
+-define(ERROR(Str, Args), error_logger:error_msg(Str, Args)).
 
 -record(state, {
           trie_id,
@@ -29,7 +32,7 @@ new({_,_,Id}) ->
           MetaSizeBytes,
           HashSizeBytes,
           Mode),
-    ?INFO("Worker ~p using trie with id ~p and sup ~p.\n", [Id, TrieId, TrieSupPid]),
+    ?INFO("Worker ~p (~p) using trie with id ~p and sup ~p.\n", [Id, self(), TrieId, TrieSupPid]),
     Root = basho_bench_config:get(trie_initial_empty_root),
     {[], _} = {trie:get_all(Root, TrieId), {{worker_id, Id}, {trie_initial_allegedly_empy_root, Root}}},
     State = #state{trie_id = TrieId, root = Root},

--- a/scripts/load_test/basho_bench_driver_trie.erl
+++ b/scripts/load_test/basho_bench_driver_trie.erl
@@ -1,0 +1,47 @@
+-module(basho_bench_driver_trie).
+
+-export([new/1,
+         run/4]).
+
+%% Macros compatible with header `basho_bench.hrl` - in order not to
+%% require including it for compiling this module:
+-define(INFO(Str, Args), error_logger:info_msg(Str, Args)).
+
+-record(state, {
+          trie_id,
+          root
+         }).
+
+new({_,_,Id}) ->
+    TrieId = basho_bench_config:get(trie_id),
+    KeySizeBytes = basho_bench_config:get(trie_key_size_bytes),
+    ValueSizeBytes = basho_bench_config:get(trie_value_size_bytes),
+    MetaSizeBytes = 0 = basho_bench_config:get(trie_meta_size_bytes),
+    HashSizeBytes = basho_bench_config:get(trie_hash_size_bytes),
+    Amount = basho_bench_config:get(trie_amount),
+    Mode = basho_bench_config:get(trie_mode),
+    {ok, TrieSupPid} =
+        trie_sup:start_link( %% TODO review linking
+          KeySizeBytes,
+          ValueSizeBytes,
+          TrieId,
+          Amount,
+          MetaSizeBytes,
+          HashSizeBytes,
+          Mode),
+    ?INFO("Worker ~p using trie with id ~p and sup ~p.\n", [Id, TrieId, TrieSupPid]),
+    Root = basho_bench_config:get(trie_initial_empty_root),
+    {[], _} = {trie:get_all(Root, TrieId), {{worker_id, Id}, {trie_initial_allegedly_empy_root, Root}}},
+    State = #state{trie_id = TrieId, root = Root},
+    {ok, State}.
+
+run(get, KeyGen, _ValueGen, State = #state{}) ->
+    Key = KeyGen(),
+    case trie:get(Key, State#state.root, State#state.trie_id) of
+        {_, empty, _} ->
+            {ok, State};
+        {_, _, _} ->
+            {ok, State};
+        Unknown ->
+            {error, Unknown}
+    end.

--- a/scripts/load_test/trie.config.template
+++ b/scripts/load_test/trie.config.template
@@ -1,5 +1,5 @@
 %% -*- mode: erlang;-*-
-{mode, {rate, 1}}. %% `max`, i.e. as many ops/s as possible, or `{rate, N}`, i.e. N ops/s, with exponentially distributed interarrival times.
+{mode, {rate, 10}}. %% `max`, i.e. as many ops/s as possible, or `{rate, N}`, i.e. N ops/s, with exponentially distributed interarrival times.
 {concurrent, 1}. %% number of concurrent workers
 {duration, 1}. %% minutes
 
@@ -7,7 +7,14 @@
 
 {driver, basho_bench_driver_trie}.
 
-{operations, [{get, 1}]}. %% weighted list of operations the driver will run
+{operations, %% weighted list of operations the driver will run
+ [ {root_hash, 1}
+ , {put, 1}
+ , {get, 1}
+ , {get_all, 1}
+ , {delete, 1}
+ , {garbage, 1}
+ ]}.
 
 {key_generator, {uniform_int, 100}}. %% 1..N
 {value_generator, {fixed_bin, 2}}. %% random binary of size N bytes

--- a/scripts/load_test/trie.config.template
+++ b/scripts/load_test/trie.config.template
@@ -1,0 +1,24 @@
+%% -*- mode: erlang;-*-
+{mode, {rate, 1}}. %% `max`, i.e. as many ops/s as possible, or `{rate, N}`, i.e. N ops/s, with exponentially distributed interarrival times.
+{concurrent, 1}. %% number of concurrent workers
+{duration, 1}. %% minutes
+
+{code_paths, CODE_PATHS_AS_STRING_LIST}. %% Paths of additional Erlang code e.g. `{code_paths, ["./foo/ebin", "./bar/ebin"]}.`
+
+{driver, basho_bench_driver_trie}.
+
+{operations, [{get, 1}]}. %% weighted list of operations the driver will run
+
+{key_generator, {uniform_int, 100}}. %% 1..N
+{value_generator, {fixed_bin, 2}}. %% random binary of size N bytes
+
+%% Driver-specific configuration below.
+{trie_id, trieLoadTest}.
+{trie_key_size_bytes, 9}.
+{trie_value_size_bytes, 2}.
+{trie_meta_size_bytes, 0}.
+{trie_hash_size_bytes, 12}.
+{trie_amount, 1000000}.
+{trie_mode, hd}.
+{trie_initial_empty_root, 0}.
+%% TODO parametrize trie storage location. E.g. `{trie_dir, "./tmp/trie.bench"}.`


### PR DESCRIPTION
Closes https://github.com/aeternity/testnet/issues/220

Depends on:
* #13 (e81b782 and history - included in this PR);
* https://github.com/BumblebeeBat/dump/pull/2 (not included in this PR, of course);
* ~#14~ #17 (not included in this PR) - for deletion-related fix.

Description of commits specific to this PR:
* 1dc4e9e Review logging in load test script (minor change)
* af594ae Script load testing of elementary trie operations - this is the main point of this PR and meant to close https://aeternity.atlassian.net/browse/AE-134

Please refer to commit messages for details.

Instructions for running the load test scripts are in the CI scripts, and also explicated in commit e81b782 (of PR #13).

----

A sample local run produced the following graph...
![summary](https://user-images.githubusercontent.com/1344255/28587865-78346dc0-7170-11e7-85b8-bc08156a0694.png)
... and below are some excerpts of the logs.
```
...
%% -*- mode: erlang;-*-
{mode, {rate, 10}}. %% `max`, i.e. as many ops/s as possible, or `{rate, N}`, i.e. N ops/s, with exponentially distributed interarrival times.
{concurrent, 1}. %% number of concurrent workers
{duration, 1}. %% minutes

{code_paths, ["/Users/luca/dev/aeternity/MerkleTrie2/tmp/ebin", "/Users/luca/dev/aeternity/MerkleTrie2/_build/default/lib/dump/ebin", "/Users/luca/dev/aeternity/MerkleTrie2/_build/default/lib/encrypter/ebin", "/Users/luca/dev/aeternity/MerkleTrie2/_b
uild/default/lib/pink_hash/ebin", "/Users/luca/dev/aeternity/MerkleTrie2/_build/default/lib/trie/ebin"]}. %% Paths of additional Erlang code e.g. `{code_paths, ["./foo/ebin", "./bar/ebin"]}.`

{driver, basho_bench_driver_trie}.

{operations, %% weighted list of operations the driver will run
 [ {root_hash, 1}
 , {put, 1}
 , {get, 1}
 , {get_all, 1}
 , {delete, 1}
 , {garbage, 1}
 ]}.

{key_generator, {uniform_int, 100}}. %% 1..N
{value_generator, {fixed_bin, 2}}. %% random binary of size N bytes

%% Driver-specific configuration below.
{trie_id, trieLoadTest}.
{trie_key_size_bytes, 9}.
{trie_value_size_bytes, 2}.
{trie_meta_size_bytes, 0}.
{trie_hash_size_bytes, 12}.
{trie_amount, 1000000}.
{trie_mode, hd}.
{trie_initial_empty_root, 0}.
%% TODO parametrize trie storage location. E.g. `{trie_dir, "./tmp/trie.bench"}.`
...
19:13:49.167 [debug] Lager installed handler {lager_file_backend,
                            "/Users/luca/dev/aeternity/MerkleTrie2/tmp/basho_bench/tests/20170725_191349/error.log"} into lager_event
19:13:49.167 [debug] Lager installed handler {lager_file_backend,
                            "/Users/luca/dev/aeternity/MerkleTrie2/tmp/basho_bench/tests/20170725_191349/console.log"} into lager_event
19:13:49.168 [debug] Lager installed handler error_logger_lager_h into error_logger
19:13:49.184 [info] Application lager started on node nonode@nohost
19:13:49.185 [notice] Changed loglevel of /Users/luca/dev/aeternity/MerkleTrie2/tmp/basho_bench/tests/20170725_191349/console.log to debug
19:13:49.213 [info] FORMAT ERROR: "Est. data size: ~.2f ~s\n" [200,bytes]
19:13:49.229 [debug] Supervisor basho_bench_run_sup started basho_bench_duration:start_link() at pid <0.128.0>
19:13:49.323 [info] module=basho_bench_stats_writer_csv event=start stats_sink=csv
19:13:49.326 [debug] Supervisor basho_bench_run_sup started basho_bench_stats:start_link() at pid <0.129.0>
19:13:49.355 [info] Random source: calling crypto:strong_rand_bytes(100663296) (override with the 'value_generator_source_size' config option
19:13:52.871 [info] Random source: finished crypto:strong_rand_bytes(100663296)
19:13:52.871 [debug] Lager installed handler lager_backend_throttle into lager_event
19:13:53.170 [debug] Supervisor {global,trieLoadTest_leafsup} started dump:start_link(11, trieLoadTest_leaf) at pid <0.142.0>
19:13:53.216 [debug] Supervisor {global,trieLoadTest_leafsup} started file_manager:start_link("data/trieLoadTest_leaf.db", trieLoadTest_leaf_file, 11000000, hd) at pid <0.143.0>
19:13:53.302 [debug] Supervisor {global,trieLoadTest_leafsup} started bits:start_link(trieLoadTest_leaf_bits, "data/trieLoadTest_leaf_bits.db", 1000000) at pid <0.144.0>
19:13:53.302 [debug] Supervisor {global,trieLoadTest} started dump_sup:start_link(trieLoadTest_leaf, 11, 1000000, hd) at pid <0.141.0>
19:13:53.303 [debug] Supervisor {global,trieLoadTest_stemsup} started dump:start_link(340, trieLoadTest_stem) at pid <0.146.0>
19:13:53.304 [debug] Supervisor {global,trieLoadTest_stemsup} started file_manager:start_link("data/trieLoadTest_stem.db", trieLoadTest_stem_file, 340000000, hd) at pid <0.147.0>
19:13:53.304 [debug] Supervisor {global,trieLoadTest_stemsup} started bits:start_link(trieLoadTest_stem_bits, "data/trieLoadTest_stem_bits.db", 1000000) at pid <0.148.0>
19:13:53.304 [debug] Supervisor {global,trieLoadTest} started dump_sup:start_link(trieLoadTest_stem, 340, 1000000, hd) at pid <0.145.0>
19:13:53.305 [debug] Supervisor {global,trieLoadTest} started bits:start_link(trieLoadTest_bits, "data/trieLoadTest_trie_bits.db", 1000000) at pid <0.149.0>
19:13:53.403 [debug] Supervisor {global,trieLoadTest} started trie:start_link({cfg,9,2,trieLoadTest,0,12}) at pid <0.150.0>
19:13:53.403 [info] Worker 1 (<0.139.0>) using trie with id trieLoadTest and sup <0.140.0>.
19:13:53.404 [debug] Supervisor basho_bench_worker_sup started basho_bench_worker:start_link(basho_bench_worker_1, {single_worker,1,1}, []) at pid <0.137.0>
19:13:53.404 [debug] Supervisor basho_bench_run_sup started basho_bench_worker_sup:start_link() at pid <0.136.0>
19:13:53.404 [debug] Supervisor basho_bench_sup started basho_bench_run_sup:start_link() at pid <0.127.0>
19:13:53.404 [debug] Supervisor kernel_safe_sup started timer:start_link() at pid <0.151.0>
19:13:53.416 [info] Starting 100.0 ms/req fixed rate worker: <0.139.0> on nonode@nohost
19:13:53.416 [info] Starting with duration: 1
19:14:53.420 [info] No Errors.
19:14:53.423 [info] module=basho_bench_stats_writer_csv event=stop stats_sink=csv
Rscript --vanilla priv/summary.r -i tests/current
...
```