### PR TITLE
AE-147 Unit test that root hash does not depend on order of operations

### DIFF
--- a/ci
+++ b/ci
@@ -40,7 +40,7 @@ case "${1:?}"-"${2:?}" in
         ;;
     script-eunit)
         BuildDir="${3:?}"
-        ( cd "${BuildDir:?}" && ./rebar3 eunit; )
+        ( cd "${BuildDir:?}" && ./rebar3 eunit && ./rebar3 proper; )
         ;;
     script-dialyzer)
         BuildDir="${3:?}"

--- a/rebar.config
+++ b/rebar.config
@@ -5,3 +5,5 @@
        {dump, "1", {git, "https://github.com/BumblebeeBat/dump", {tag, "master"}}}
 ]}.
 
+{plugins, [rebar3_proper]}.
+{profiles, [{test, [{deps, [{proper, "1.2.0"}]}]}]}.

--- a/src/delete.erl
+++ b/src/delete.erl
@@ -4,11 +4,13 @@
 -spec delete(leaf:key(), stem:stem_p(), cfg:cfg()) -> stem:stem_p().
 delete(ID, Root, CFG) ->
     Path = leaf:path_maker(ID, CFG),
-    Branch = store:get_branch(Path, 0, Root, [], CFG),
-    %{_, Leaf, Proof} = get:get(Path, Root, CFG),
-    X = cfg:hash_size(CFG)*8,
-    %X = hash:hash_depth()*8,
-    EmptyHash = <<0:X>>,
-    {_, NewRoot, _} = store:store_branch(Branch, Path, 0, 0, EmptyHash, CFG),
-    NewRoot.
+    case store:get_branch(Path, 0, Root, [], CFG) of
+	{_, _, _} -> %already no leaf with the specified path
+	    Root;
+	Branch ->
+	    X = cfg:hash_size(CFG)*8,
+	    EmptyHash = <<0:X>>,
+	    {_, NewRoot, _} = store:store_branch(Branch, Path, 0, 0, EmptyHash, CFG),
+	    NewRoot
+    end.
 

--- a/test/prop_trie_arbitrary_put_and_delete.erl
+++ b/test/prop_trie_arbitrary_put_and_delete.erl
@@ -1,0 +1,96 @@
+-module(prop_trie_arbitrary_put_and_delete).
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("proper/include/proper.hrl").
+
+-export([command/1, initial_state/0, next_state/3,
+         precondition/2, postcondition/3]).
+
+-define(ID, triePropTest).
+
+prop_from_data_dir_as_it_is() ->
+    ?FORALL(Cmds, commands(?MODULE),
+	    begin
+		R = setup_trie(?ID),
+		{History, State, Result} = run_commands(?MODULE, Cmds),
+		cleanup_trie(R),
+		?WHENFAIL(io:format("History: ~p~nState: ~p~nResult: ~p~n",
+				    [History, State, Result]),
+			  aggregate(command_names(Cmds), Result =:= ok))
+	    end).
+
+prop_from_clean_data_dir() ->
+    {ok, Cwd} = file:get_cwd(),
+    DataDir = filename:join([Cwd, "data"]),
+    cleanup_for_clean_data_dir(DataDir),
+    ?FORALL(Cmds, commands(?MODULE),
+	    begin
+		R1 = setup_for_clean_data_dir(DataDir),
+		R2 = setup_trie(?ID),
+		{History, State, Result} = run_commands(?MODULE, Cmds),
+		cleanup_trie(R2),
+		cleanup_for_clean_data_dir(R1),
+		?WHENFAIL(io:format("History: ~p~nState: ~p~nResult: ~p~n",
+				    [History, State, Result]),
+			  aggregate(command_names(Cmds), Result =:= ok))
+	    end).
+
+setup_trie(Id) ->
+    {ok, SupPid} = trie_sup:start_link(
+		     _KeyLength = 9,
+		     _Size = 2,
+		     _ID = Id,
+		     _Amount = 1000000,
+		     _Meta = 2,
+		     _HashSize = 12,
+		     _Mode = hd),
+    SupPid.
+
+cleanup_trie(SupPid) ->
+    cleanup_alive_sup(SupPid).
+
+setup_for_clean_data_dir(DataDir) ->
+    ?assert(filelib:is_dir(DataDir)),
+    ?assertEqual({ok, []}, file:list_dir_all(DataDir)),
+    DataDir.
+
+cleanup_for_clean_data_dir(DataDir) ->
+    DbFiles = filelib:wildcard(filename:join([DataDir, "*.db"])),
+    lists:foreach(fun(F) -> {ok, _} = {file:delete(F), F} end, DbFiles),
+    ?assertEqual({ok, []}, file:list_dir_all(DataDir)),
+    ok.
+
+cleanup_alive_sup(Sup) when is_pid(Sup) ->
+    SupMonRef = erlang:monitor(process, Sup),
+    unlink(Sup),
+    exit(Sup, Reason = shutdown),
+    receive
+	{'DOWN', SupMonRef, process, Sup, R} ->
+	    Reason = R,
+	    ok
+    end,
+    ok.
+
+-record(state, {root}).
+
+initial_state() ->
+    #state{root = 0}.
+
+command(State) ->
+    Root = State#state.root,
+    oneof([{call, trie, put, [leaf_key(), <<1,1>>, 0, Root, ?ID]},
+	   {call, trie, delete, [leaf_key(), Root, ?ID]}
+	  ]).
+
+precondition(#state{}, {call, _Mod, _Fun, _Args}) ->
+    true.
+
+leaf_key() ->
+    integer(1, 100).
+
+next_state(State, Res, {call, trie, put, _Args}) ->
+    State#state{root = Res};
+next_state(State, Res, {call, trie, delete, _Args}) ->
+    State#state{root = Res}.
+
+postcondition(_State, {call, _Mod, _Fun, _Args}, _Res) ->
+    true.

--- a/test/prop_trie_root_hash_independent_from_order_of_operations.erl
+++ b/test/prop_trie_root_hash_independent_from_order_of_operations.erl
@@ -1,0 +1,79 @@
+-module(prop_trie_root_hash_independent_from_order_of_operations).
+
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("proper/include/proper.hrl").
+
+-define(ID, triePropTest).
+
+prop_put_each_key_only_once_and_no_delete() ->
+    {ok, Cwd} = file:get_cwd(),
+    DataDir = filename:join([Cwd, "data"]),
+    trie_test_utils:cleanup_for_clean_data_dir(DataDir),
+    ?FORALL({DistinctLeafKeys, ShuffledDistinctLeafKeys},
+	    distinct_leaf_keys_and_shuffled(0, 99),
+	    begin
+		?assertEqual(length(DistinctLeafKeys),
+			     length(ShuffledDistinctLeafKeys)),
+		RH1 = trie_put_all_and_compute_root_hash_in_clean_data_dir(
+			DataDir, ?ID, 0, DistinctLeafKeys),
+		RH2 = trie_put_all_and_compute_root_hash_in_clean_data_dir(
+			DataDir, ?ID, 0, ShuffledDistinctLeafKeys),
+		%% io:format(
+		%%   "Put ~p elements in two trees and comparing their root hashes ~w and ~w.~nInitial elements in first tree are:~n  ~w~nInitial elements in second tree are:~n  ~w~n",
+		%%   [length(DistinctLeafKeys),
+		%%    RH1, RH1,
+		%%    lists:sublist(DistinctLeafKeys, 3),
+		%%    lists:sublist(ShuffledDistinctLeafKeys, 3)]),
+		RH1 == RH2
+	    end).
+
+trie_put_all_and_compute_root_hash_in_clean_data_dir(DataDir, Id, Root, Keys) ->
+    R1 = trie_test_utils:setup_for_clean_data_dir(DataDir),
+    R2 = setup_trie(Id),
+    NewRoot =
+	lists:foldl(
+	  fun(K, R) ->
+		  trie:put(K, _V = <<K:(2*8)>>, _M = 0, R, Id)
+	  end,
+	  Root,
+	  Keys),
+    RH = trie:root_hash(Id, NewRoot),
+    cleanup_trie(R2),
+    trie_test_utils:cleanup_for_clean_data_dir(R1),
+    RH.
+
+setup_trie(Id) ->
+    {ok, SupPid} = trie_sup:start_link(
+		     _KeyLength = 9,
+		     _Size = 2,
+		     _ID = Id,
+		     _Amount = 1000000,
+		     _Meta = 2,
+		     _HashSize = 12,
+		     _Mode = hd),
+    SupPid.
+
+cleanup_trie(SupPid) ->
+    trie_test_utils:cleanup_alive_sup(SupPid).
+
+distinct_leaf_keys_and_shuffled(Low, High) ->
+    ?LET(Ks, distinct_leaf_keys(Low, High), {Ks, shuffle(Ks)}).
+
+distinct_leaf_keys(Low, High) ->
+    ulist(leaf_key(Low, High)).
+
+leaf_key(Low, High) ->
+    integer(Low, High).
+
+%% From https://github.com/manopapad/proper/blob/v1.2/test/proper_tests.erl#L1457-L1458
+ulist(ElemType) ->
+    ?SUCHTHAT(L, list(ElemType), no_duplicates(L)).
+%% From https://github.com/manopapad/proper/blob/v1.2/test/proper_tests.erl#L1219-L1220
+no_duplicates(L) ->
+    length(lists:usort(L)) =:= length(L).
+
+%% From https://github.com/manopapad/proper/blob/v1.2/test/proper_tests.erl#L1306-L1309
+shuffle([]) ->
+    [];
+shuffle(L) ->
+    ?LET(X, elements(L), [X | shuffle(lists:delete(X,L))]).

--- a/test/trie_test_utils.erl
+++ b/test/trie_test_utils.erl
@@ -1,0 +1,28 @@
+-module(trie_test_utils).
+
+-export([cleanup_alive_sup/1,
+	 setup_for_clean_data_dir/1, cleanup_for_clean_data_dir/1]).
+
+-include_lib("stdlib/include/assert.hrl").
+
+cleanup_alive_sup(Sup) when is_pid(Sup) ->
+    SupMonRef = erlang:monitor(process, Sup),
+    unlink(Sup),
+    exit(Sup, Reason = shutdown),
+    receive
+	{'DOWN', SupMonRef, process, Sup, R} ->
+	    Reason = R,
+	    ok
+    end,
+    ok.
+
+setup_for_clean_data_dir(DataDir) ->
+    ?assert(filelib:is_dir(DataDir)),
+    ?assertEqual({ok, []}, file:list_dir_all(DataDir)),
+    DataDir.
+
+cleanup_for_clean_data_dir(DataDir) ->
+    DbFiles = filelib:wildcard(filename:join([DataDir, "*.db"])),
+    lists:foreach(fun(F) -> {ok, _} = {file:delete(F), F} end, DbFiles),
+    ?assertEqual({ok, []}, file:list_dir_all(DataDir)),
+    ok.

--- a/test/trie_tests.erl
+++ b/test/trie_tests.erl
@@ -22,7 +22,7 @@ api_smoke_test_() ->
      end,
      fun(SupPid) ->
 	     ?assert(is_process_alive(SupPid)),
-	     cleanup_alive_sup(SupPid),
+	     trie_test_utils:cleanup_alive_sup(SupPid),
 	     ?assertNot(is_process_alive(SupPid)),
 	     ok
      end,
@@ -56,7 +56,7 @@ root_hash_test_() ->
      end,
      fun(SupPid) ->
 	     ?assert(is_process_alive(SupPid)),
-	     cleanup_alive_sup(SupPid),
+	     trie_test_utils:cleanup_alive_sup(SupPid),
 	     ?assertNot(is_process_alive(SupPid)),
 	     ok
      end,
@@ -163,7 +163,7 @@ key_range_good_test_() ->
      end,
      fun(SupPid) ->
 	     ?assert(is_process_alive(SupPid)),
-	     cleanup_alive_sup(SupPid),
+	     trie_test_utils:cleanup_alive_sup(SupPid),
 	     ?assertNot(is_process_alive(SupPid)),
 	     ok
      end,
@@ -239,7 +239,7 @@ delete_unexistent_key_test_() ->
      end,
      fun(SupPid) ->
 	     ?assert(is_process_alive(SupPid)),
-	     cleanup_alive_sup(SupPid),
+	     trie_test_utils:cleanup_alive_sup(SupPid),
 	     ?assertNot(is_process_alive(SupPid)),
 	     ok
      end,
@@ -282,7 +282,7 @@ gc_test_() ->
      end,
      fun(SupPid) ->
 	     ?assert(is_process_alive(SupPid)),
-	     cleanup_alive_sup(SupPid),
+	     trie_test_utils:cleanup_alive_sup(SupPid),
 	     ?assertNot(is_process_alive(SupPid)),
 	     ok
      end,
@@ -321,17 +321,6 @@ gc_test_() ->
 	end}
      ]
     }.
-
-cleanup_alive_sup(Sup) when is_pid(Sup) ->
-    SupMonRef = erlang:monitor(process, Sup),
-    unlink(Sup),
-    exit(Sup, Reason = shutdown),
-    receive
-	{'DOWN', SupMonRef, process, Sup, R} ->
-	    Reason = R,
-	    ok
-    end,
-    ok.
 
 assert_trie_empty(Root = 0, Id) ->
     ?assertEqual([], trie:get_all(Root, Id)),

--- a/test/trie_tests.erl
+++ b/test/trie_tests.erl
@@ -36,6 +36,113 @@ api_smoke_test_() ->
      ]
     }.
 
+root_hash_test_() ->
+    {foreach,
+     fun() ->
+	     ?debugFmt("~nCurrent working directory: ~p~n",
+		       [begin {ok, Cwd} = file:get_cwd(), Cwd end]),
+	     {ok, SupPid} =
+		 trie_sup:start_link(
+		   _KeyLength = 9,
+		   _Size = 2,
+		   _ID = ?ID,
+		   _Amount = 1000000,
+		   _Meta = 2,
+		   _HashSize = 12,
+		   _Mode = hd),
+	     ?debugFmt("~nTrie sup pid: ~p~n", [SupPid]),
+	     assert_trie_empty(0, ?ID),
+	     SupPid
+     end,
+     fun(SupPid) ->
+	     ?assert(is_process_alive(SupPid)),
+	     cleanup_alive_sup(SupPid),
+	     ?assertNot(is_process_alive(SupPid)),
+	     ok
+     end,
+     [ {"Hash of root of empty tree",
+	fun() ->
+		Root = 0,
+		RH = trie:root_hash(?ID, Root),
+		?assertMatch({RH, empty, _}, trie:get(_Key = 1, Root, ?ID)),
+		ok
+	end}
+     , {"Hash of tree root changes with tree content",
+	fun() ->
+		Root = 0,
+		RH = trie:root_hash(?ID, Root),
+		Key = 1,
+		Root2 = trie:put(Key, _V = <<1,1>>, _Meta = 0, Root, ?ID),
+		RH2 = trie:root_hash(?ID, Root2),
+		?assertMatch({RH2, _, _}, trie:get(Key, Root2, ?ID)),
+		?assertNotEqual(RH, RH2),
+		ok
+	end}
+     , {"Hash of tree root changes with leaf key",
+	fun() ->
+		Root = 0,
+		K1 = 1,
+		K2 = 2,
+		V = <<1,1>>,
+		Meta = 0,
+		Root2A = trie:put(K1, V, Meta, Root, ?ID),
+		Root2B = trie:put(K2, V, Meta, Root, ?ID),
+		?assertNotEqual(trie:root_hash(?ID, Root2A),
+				trie:root_hash(?ID, Root2B)),
+		ok
+	end}
+     , {"Hash of tree root changes with leaf value",
+	fun() ->
+		Root = 0,
+		K = 1,
+		V1 = <<1,1>>,
+		V2 = <<1,2>>,
+		Meta = 0,
+		Root2A = trie:put(K, V1, Meta, Root, ?ID),
+		Root2B = trie:put(K, V2, Meta, Root, ?ID),
+		?assertNotEqual(trie:root_hash(?ID, Root2A),
+				trie:root_hash(?ID, Root2B)),
+		ok
+	end}
+     , {"Hash of tree root does not change with leaf meta",
+	fun() ->
+		Root = 0,
+		K = 1,
+		V = <<1,1>>,
+		Meta1 = 0,
+		Meta2 = 1,
+		Root2A = trie:put(K, V, Meta1, Root, ?ID),
+		Root2B = trie:put(K, V, Meta2, Root, ?ID),
+		?assertEqual(trie:root_hash(?ID, Root2A),
+			     trie:root_hash(?ID, Root2B)),
+		ok
+	end}
+     , {"Hash of tree root depends on tree content rather than order of operations - case empty tree",
+	fun() ->
+		Root = 0,
+		Key = 1,
+		Root2 = trie:put(Key, _V = <<1,1>>, _Meta = 0, Root, ?ID),
+		Root3 = trie:delete(Key, Root2, ?ID),
+		?assertEqual(trie:root_hash(?ID, Root),
+			     trie:root_hash(?ID, Root3)),
+		ok
+	end}
+     , {"Hash of tree root depends on tree content rather than order of operations - case non-empty tree",
+	fun() ->
+		Root = 0,
+		K1 = 1,
+		K2 = 2,
+		Meta = 0,
+		Root2 = trie:put(K1, _V1 = <<1,1>>, Meta, Root, ?ID),
+		Root3 = trie:put(K2, _V2 = <<1,2>>, Meta, Root2, ?ID),
+		Root4 = trie:delete(K2, Root3, ?ID),
+		?assertEqual(trie:root_hash(?ID, Root2),
+			     trie:root_hash(?ID, Root4)),
+		ok
+	end}
+     ]
+    }.
+
 key_range_good_test_() ->
     {foreach,
      fun() ->

--- a/test/trie_tests.erl
+++ b/test/trie_tests.erl
@@ -251,10 +251,8 @@ delete_unexistent_key_test_() ->
 		K1 = 90,
 		K2 = 26,
 		%% The keys share the first nibble of the path.
-		?assertMatch({<<N1:4, _/bitstring>>,
-			      <<N1:4, _/bitstring>>},
-			     {leaf:path_maker(K1, trie:cfg(?ID)),
-			      leaf:path_maker(K2, trie:cfg(?ID))}),
+		?assertEqual(hd(leaf:path_maker(K1, trie:cfg(?ID))),
+			     hd(leaf:path_maker(K2, trie:cfg(?ID)))),
 		trie:delete(
 		  K2,
 		  trie:put(K1, _V = <<1,1>>, _Meta = 1, _Root = 0, ?ID),


### PR DESCRIPTION
I consider this PR sufficient for closing AE-147.
Closes https://github.com/aeternity/testnet/issues/221

Depends on #17 (included in this PR).

The only commits specific to this PR are:
* c8dfc9c refactoring for easing writing tests
* 471ffe8 test on effect of order of push on root hash

I did not introduce tests for checking the effect of delete operations because I consider it sufficiently tested by the two test cases at:
* https://github.com/BumblebeeBat/MerkleTrie/pull/17/commits/3ba7e417e6e0ef9fd2bde75499b2140208c1b2d2#diff-ebf0a39b30ec87dafb83c96ee9b1739aR120
* https://github.com/BumblebeeBat/MerkleTrie/pull/17/commits/3ba7e417e6e0ef9fd2bde75499b2140208c1b2d2#diff-ebf0a39b30ec87dafb83c96ee9b1739aR130


